### PR TITLE
Fix NewRemoteSwitch examples to fully support ESPs

### DIFF
--- a/examples/NewRemoteSwitch examples cc1101/LightShow_cc1101/LightShow_cc1101.ino
+++ b/examples/NewRemoteSwitch examples cc1101/LightShow_cc1101/LightShow_cc1101.ino
@@ -15,6 +15,17 @@
  * To use this actual example, you'd need to "learn" the used code in the receivers
  * This sketch is unsuited for that.
  * 
+ * Works on any Arduino AVR, ESP8266 or ESP32. NewRemoteSwitch library commit:  
+ * c3ca4cb (Sep 19, 2021) or later, required to work properly on ESP8266 and ESP32.
+ * 
+ * Set-up: connect CC1101 SPI:
+ *                          SCK  MISO MOSI  SS
+ * Arduino UNO/Nano  (pin)   13   12   11   10
+ * Arduino Mega2560  (pin)   52   50   51   53
+ * Espressif ESP8266 (GPIO)  14   12   13   15  (digital pins depends board)
+ * Espressif ESP32   (GPIO)  18   19   23    5  (digital pins depends board)
+ * 
+ * Set-up: connect CC1101 GDO0 pin to a digital pin to transmit. See below.
  * 
  *  https://github.com/1technophile/NewRemoteSwitch
  *  https://github.com/LSatan/SmartRC-CC1101-Driver-Lib
@@ -31,11 +42,11 @@ int pin; // int for Transmit pin.
 void setup() {
 
 #ifdef ESP32
-pin = 2;  // for esp32! Transmit on GPIO pin 2.
+pin = 14;  // for esp32! Transmit on GPIO 14 (digital pin depends board).
 #elif ESP8266
-pin = 5;  // for esp8266! Transmit on pin 5 = D1
+pin = 5;  // for esp8266! Transmit on GPIO 5 (digital pin depends board).
 #else
-pin = 6;  // for Arduino! Transmit on pin 6.
+pin = 6;  // for Arduino! Transmit on digital pin 6 (Arduino).
 #endif 
 
 //CC1101 Settings:                (Settings with "//" are optional!)
@@ -44,12 +55,13 @@ pin = 6;  // for Arduino! Transmit on pin 6.
 //ELECHOUSE_cc1101.setPA(10);       // set TxPower. The following settings are possible depending on the frequency band.  (-30  -20  -15  -10  -6    0    5    7    10   11   12)   Default is max!
   ELECHOUSE_cc1101.setMHZ(433.92); // Here you can set your basic frequency. The lib calculates the frequency automatically (default = 433.92).The cc1101 can: 300-348 MHZ, 387-464MHZ and 779-928MHZ. Read More info from datasheet.
 
-  ELECHOUSE_cc1101.SetTx();     // cc1101 set Transmit on
 }
 
 void loop() { 
 
-  // Create a transmitter on address 123, using digital pin 6 to transmit, 
+  ELECHOUSE_cc1101.SetTx();     // cc1101 set Transmit on
+
+  // Create a transmitter on address 123, using a digital pin to transmit, 
   // with a period duration of 260ms (default), repeating the transmitted
   // code 2^3=8 times.
   NewRemoteTransmitter transmitter(123, pin, 260, 3);
@@ -63,9 +75,12 @@ void loop() {
   // Set unit 1 to dim-level 3 (range 0-15)
   transmitter.sendDim(1, 3);  
 
+  ELECHOUSE_cc1101.setSidle();  // set Idle (Transmit off)
+
   // Wait 5 seconds
   delay(5000);
   
+  ELECHOUSE_cc1101.SetTx();     // cc1101 set Transmit on
 
   // Switch unit 2 on
   transmitter.sendUnit(2, true);
@@ -75,6 +90,8 @@ void loop() {
 
   // Set unit 1 to dim-level 15, full brightness.
   transmitter.sendDim(1, 15);
+
+  ELECHOUSE_cc1101.setSidle();  // cc1101 set Idle (Transmit off)
 
   // Wait 5 seconds
   delay(5000);

--- a/examples/NewRemoteSwitch examples cc1101/Retransmitter_cc1101/Retransmitter_cc1101.ino
+++ b/examples/NewRemoteSwitch examples cc1101/Retransmitter_cc1101/Retransmitter_cc1101.ino
@@ -6,7 +6,21 @@
  * When run, this sketch waits for a valid code from a new-style the receiver,
  * decodes it, and retransmits it after 5 seconds.
  * 
- *  Notes: Arduino only!!!
+ * Works on any Arduino AVR, ESP8266 or ESP32. NewRemoteSwitch library commit:  
+ * c3ca4cb (Sep 19, 2021) or later, required to work properly on ESP8266 and ESP32.
+ * 
+ * To prevent kernel panic for interrupt wdt timeout on ESP8266 and ESP32, 
+ * the retransmission of the received code is done in loop() function.
+ * 
+ * Set-up: connect CC1101 SPI:
+ *                          SCK  MISO MOSI  SS
+ * Arduino UNO/Nano  (pin)   13   12   11   10
+ * Arduino Mega2560  (pin)   52   50   51   53
+ * Espressif ESP8266 (GPIO)  14   12   13   15  (digital pins depends board)
+ * Espressif ESP32   (GPIO)  18   19   23    5  (digital pins depends board)
+ * 
+ * Set-up: connect CC1101 GDO2 pin to an attachable interruption pin. See below.
+ * Set-up: connect CC1101 GDO0 pin to a digital pin to transmit. See below.
  *  
  *  https://github.com/1technophile/NewRemoteSwitch
  *  https://github.com/LSatan/SmartRC-CC1101-Driver-Lib
@@ -19,6 +33,9 @@
 #include <NewRemoteReceiver.h>
 #include <NewRemoteTransmitter.h>
 
+NewRemoteCode receivedCode;   // Global var to store received code for retramitt it
+boolean codeLearned = false;  // Flag to set a valid learned code has been received
+
 void setup() {
 
 //CC1101 Settings:                (Settings with "//" are optional!)
@@ -29,52 +46,89 @@ void setup() {
 
   ELECHOUSE_cc1101.SetRx();  // set Receive on 
   
-  // See example ShowReceivedCode for info on this
-  NewRemoteReceiver::init(0, 2, retransmitter);
+  // Initialize receiver on interrupt 0 (= digital pin 2) for Arduino Uno. 
+  // On ESP8266 and ESP32 use on GPIO 4 = digital pin depends board. 
+  // Review file "pins_arduino.h" of your variant:
+  //   https://github.com/esp8266/Arduino/tree/master/variants
+  //   https://github.com/espressif/arduino-esp32/tree/master/variants
+  //
+  // See the interrupt-parameter of attachInterrupt for possible values (and pins)
+  // to connect the receiver.
+  //
+  // Calls the callback "retransmitter" after 2 identical codes have been received 
+  // in a row. (thus, keep the button pressed for a moment).
+  
+  #if defined ESP8266 || defined ESP32
+    NewRemoteReceiver::init(4, 2, retransmitter);
+  #else
+    NewRemoteReceiver::init(0, 2, retransmitter);
+  #endif
 }
 
 void loop() {
+
+  if (codeLearned) {
+
+    // Clear flag
+    codeLearned = false;
+
+    // Wait 5 seconds before sending.
+    delay(5000);
+
+    ELECHOUSE_cc1101.SetTx();  // set Transmit on (Receive off)
+
+    // Create a new transmitter with the received address and period, use a digital pin as output pin
+    #if defined ESP32
+    NewRemoteTransmitter transmitter(receivedCode.address, 14, receivedCode.period); // Transmit on GPIO 14 (digital pin depends board)
+    #elif defined ESP8266 
+    NewRemoteTransmitter transmitter(receivedCode.address, 5, receivedCode.period);  // Transmit on GPIO 5 (digital pin depends board)
+    #else
+    NewRemoteTransmitter transmitter(receivedCode.address, 6, receivedCode.period);  // Transmit on digital pin 6 (Arduino)
+    #endif
+
+    if (receivedCode.switchType == NewRemoteCode::dim || 
+      (receivedCode.switchType == NewRemoteCode::on && receivedCode.dimLevelPresent)) {
+      // Dimmer signal received
+
+      if (receivedCode.groupBit) {
+        transmitter.sendGroupDim(receivedCode.dimLevel);
+      } 
+      else {
+        transmitter.sendDim(receivedCode.unit, receivedCode.dimLevel);
+      }
+    } 
+    else {
+      // On/Off signal received
+      bool isOn = receivedCode.switchType == NewRemoteCode::on;
+
+      if (receivedCode.groupBit) {
+        // Send to the group
+        transmitter.sendGroup(isOn);
+      } 
+      else {
+        // Send to a single unit
+        transmitter.sendUnit(receivedCode.unit, isOn);
+      }
+    }
+
+    ELECHOUSE_cc1101.setSidle();  // set Idle (Receive off and Transmit off)
+
+    NewRemoteReceiver::enable();
+
+    ELECHOUSE_cc1101.SetRx();  // set Receive on (Transmit off)
+
+  }
 }
 
-void retransmitter(NewRemoteCode receivedCode) {
+void retransmitter(NewRemoteCode retransmitterCode) {
+
   // Disable the receiver; otherwise it might pick up the retransmit as well.
   NewRemoteReceiver::disable();
 
-  // Need interrupts for delay()
-  interrupts();
+  // Store received code for retramitt it in loop()
+  receivedCode = retransmitterCode;
 
-  // Wait 5 seconds before sending.
-  delay(5000);
+  // Set valid learned code has been received
+  codeLearned = true;
 
-  // Create a new transmitter with the received address and period, use digital pin as output pin
-
-  ELECHOUSE_cc1101.SetTx();  // set Transmit on
-  NewRemoteTransmitter transmitter(receivedCode.address, 6, receivedCode.period);
-
-  if (receivedCode.switchType == NewRemoteCode::dim || 
-    (receivedCode.switchType == NewRemoteCode::on && receivedCode.dimLevelPresent)) {
-    // Dimmer signal received
-
-    if (receivedCode.groupBit) {
-      transmitter.sendGroupDim(receivedCode.dimLevel);
-    } 
-    else {
-      transmitter.sendDim(receivedCode.unit, receivedCode.dimLevel);
-    }
-  } 
-  else {
-    // On/Off signal received
-    bool isOn = receivedCode.switchType == NewRemoteCode::on;
-
-    if (receivedCode.groupBit) {
-      // Send to the group
-      transmitter.sendGroup(isOn);
-    } 
-    else {
-      // Send to a single unit
-      transmitter.sendUnit(receivedCode.unit, isOn);
-    }
-  }
-  ELECHOUSE_cc1101.SetRx();  // set Receive on
-  NewRemoteReceiver::enable();
 }

--- a/examples/NewRemoteSwitch examples cc1101/ShowReceivedCode_cc1101/ShowReceivedCode_cc1101.ino
+++ b/examples/NewRemoteSwitch examples cc1101/ShowReceivedCode_cc1101/ShowReceivedCode_cc1101.ino
@@ -3,7 +3,7 @@
 * For details, see RemoteReceiver.h!
 *
 * This sketch shows the received signals on the serial port.
-* Connect the receiver to digital pin 2 on arduino and digital pin 1 on ESP8266.
+* Connect the receiver to an attachable interruption pin. See below.
 * 
 * 
 *Detected codes example:
@@ -11,6 +11,18 @@
  unit: 1
  groupBit: 0
  switchType: 0
+
+* Works on any Arduino AVR, ESP8266 or ESP32. NewRemoteSwitch library commit:  
+* c3ca4cb (Sep 19, 2021) or later, required to work properly on ESP8266 and ESP32.
+*
+* Set-up: connect CC1101 SPI:
+*                          SCK  MISO MOSI  SS
+* Arduino UNO/Nano  (pin)   13   12   11   10
+* Arduino Mega2560  (pin)   52   50   51   53
+* Espressif ESP8266 (GPIO)  14   12   13   15  (digital pins depends board)
+* Espressif ESP32   (GPIO)  18   19   23    5  (digital pins depends board)
+* 
+* Set-up: connect CC1101 GDO2 pin to an attachable interruption pin. See below.
 * 
 *  https://github.com/1technophile/NewRemoteSwitch
 *  https://github.com/LSatan/SmartRC-CC1101-Driver-Lib
@@ -22,15 +34,21 @@
 #include <ELECHOUSE_CC1101_SRC_DRV.h>
 #include <NewRemoteReceiver.h>
 
-int pin; // int for Receive pin.
+int pin; // int for Receive interrupt or GPIO number.
 
 void setup() {
   Serial.begin(115200);
 
+// Initialize receiver on interrupt 0 (= digital pin 2) for Arduino Uno. 
+// On ESP8266 and ESP32 use on GPIO 4 = digital pin depends board. 
+// Review file "pins_arduino.h" of your variant:
+//   https://github.com/esp8266/Arduino/tree/master/variants
+//   https://github.com/espressif/arduino-esp32/tree/master/variants
+//
 #ifdef ESP32
-pin = 4;  // for esp32! Receiver on GPIO pin 4. 
+pin = 4;  // for esp32! Receiver on GPIO 4 (digital pin depends board).
 #elif ESP8266
-pin = 4;  // for esp8266! Receiver on pin 4 = D2.
+pin = 4;  // for esp8266! Receiver on GPIO 4 (digital pin depends board).
 #else
 pin = 0;  // for Arduino! Receiver on interrupt 0 => that is pin #2
 #endif  
@@ -58,7 +76,7 @@ void loop() {
 }
 
 // Callback function is called only when a valid code is received.
-void showCode(unsigned int period, unsigned long address, unsigned long groupBit, unsigned long unit, unsigned long switchType) {
+void showCode(unsigned int period, unsigned long address, unsigned long groupBit, unsigned long unit, unsigned long switchType, boolean dimLevelPresent, byte dimLevel) {
 
   // Print the received code.
   Serial.print("Code: ");
@@ -71,5 +89,10 @@ void showCode(unsigned int period, unsigned long address, unsigned long groupBit
   Serial.println(groupBit);
   Serial.print(" switchType: ");
   Serial.println(switchType);
+
+  if (dimLevelPresent){
+    Serial.print(" dimLevel: ");
+    Serial.println(dimLevel);    
+  }
 
 }


### PR DESCRIPTION

Hi!.

After [fixing some issues in NewRemoteSwitch library](https://github.com/1technophile/NewRemoteSwitch/pull/11#issue-1000422878), including full support for ESP8266 and ESP32, it is necessary to update SmartRC-CC1101-Driver-Lib usage examples.

I have taken the opportunity to add some improvements and corrections, mainly for ESP8266, since it not works correctly direct switch from TX to RX mode, being necessary to previously go through the Idle mode. TX -> Idle -> RX. It only occurs to me that it is because in ESP8266 only GPIO 4 and 5 are available, which overlap with the I2C bus and most of the boards put these lines in pull-up.

I have tested the five examples in a real environment, both on Arduino AVR as ESP8266 and ESP32, all working correctly.

Hope I can help other users with my little contribution.
Regards!