### PR TITLE
Fix warnings found with "--warnings more"

### DIFF
--- a/ELECHOUSE_CC1101_SRC_DRV.cpp
+++ b/ELECHOUSE_CC1101_SRC_DRV.cpp
@@ -139,15 +139,15 @@ void ELECHOUSE_CC1101::GDO0_Set (void)
 ****************************************************************/
 void ELECHOUSE_CC1101::Reset (void)
 {
-	digitalWrite(SS_PIN, LOW);
-	delay(1);
-	digitalWrite(SS_PIN, HIGH);
-	delay(1);
-	digitalWrite(SS_PIN, LOW);
-	while(digitalRead(MISO_PIN));
+  digitalWrite(SS_PIN, LOW);
+  delay(1);
+  digitalWrite(SS_PIN, HIGH);
+  delay(1);
+  digitalWrite(SS_PIN, LOW);
+  while(digitalRead(MISO_PIN));
   SPI.transfer(CC1101_SRES);
   while(digitalRead(MISO_PIN));
-	digitalWrite(SS_PIN, HIGH);
+  digitalWrite(SS_PIN, HIGH);
 }
 /****************************************************************
 *FUNCTION NAME:Init
@@ -442,7 +442,7 @@ setPA(pa);
 ****************************************************************/
 void ELECHOUSE_CC1101::setPA(int p)
 {
-int a;
+int a = 0;
 pa = p;
 
 if (MHz >= 300 && MHz <= 348){
@@ -980,7 +980,6 @@ int calc = SpiReadStatus(19);
 m1FEC = 0;
 m1PRE = 0;
 m1CHSP = 0;
-int s2 = 0;
 for (bool i = 0; i==0;){
 if (calc >= 128){calc-=128; m1FEC+=128;}
 else if (calc >= 16){calc-=16; m1PRE+=16;}


### PR DESCRIPTION
Fix warnings found with "--warnings more":
```
/home/runner/Arduino/libraries/SmartRC-CC1101-Driver-Lib/ELECHOUSE_CC1101_SRC_DRV.cpp: In member function 'void ELECHOUSE_CC1101::Reset()':
/home/runner/Arduino/libraries/SmartRC-CC1101-Driver-Lib/ELECHOUSE_CC1101_SRC_DRV.cpp:149:3: error: this 'while' clause does not guard... [-Werror=misleading-indentation]
   while(digitalRead(MISO_PIN));
   ^~~~~
/home/runner/Arduino/libraries/SmartRC-CC1101-Driver-Lib/ELECHOUSE_CC1101_SRC_DRV.cpp:150:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'while'
  digitalWrite(SS_PIN, HIGH);
  ^~~~~~~~~~~~
/home/runner/Arduino/libraries/SmartRC-CC1101-Driver-Lib/ELECHOUSE_CC1101_SRC_DRV.cpp: In member function 'void ELECHOUSE_CC1101::Split_MDMCFG1()':
/home/runner/Arduino/libraries/SmartRC-CC1101-Driver-Lib/ELECHOUSE_CC1101_SRC_DRV.cpp:983:5: error: unused variable 's2' [-Werror=unused-variable]
 int s2 = 0;
     ^~
/home/runner/Arduino/libraries/SmartRC-CC1101-Driver-Lib/ELECHOUSE_CC1101_SRC_DRV.cpp: In member function 'void ELECHOUSE_CC1101::setPA(int)':
/home/runner/Arduino/libraries/SmartRC-CC1101-Driver-Lib/ELECHOUSE_CC1101_SRC_DRV.cpp:445:5: error: 'a' may be used uninitialized in this function [-Werror=maybe-uninitialized]
 int a;
     ^
cc1plus: some warnings being treated as errors
```