### PR TITLE
Missing Spi.end() before RegConfigSettings() caused ESP32-C3 to hang

### DIFF
--- a/ELECHOUSE_CC1101_SRC_DRV.cpp
+++ b/ELECHOUSE_CC1101_SRC_DRV.cpp
@@ -163,8 +163,8 @@ void ELECHOUSE_CC1101::Init(void)
   digitalWrite(SCK_PIN, HIGH);
   digitalWrite(MOSI_PIN, LOW);
   Reset();                    //CC1101 reset
-  RegConfigSettings();            //CC1101 register config
   SpiEnd();
+  RegConfigSettings();            //CC1101 register config
 }
 /****************************************************************
 *FUNCTION NAME:SpiWriteReg


### PR DESCRIPTION
RegConfigSettings() also does SPI.begin() and SPI.end(), which seems to make the code stop since there was two SPI.begin() wihtout an SPI.end() in between. Moving SpiEnd() to before RegConfigSettings() matches the Spi.begin() from SpiStart() and solves the issue.

Using Arduino 2.3.2 and esp32 arduino core 3.0.3