### PR TITLE
Hability to share SPI with TFT and Other devices

### DIFF
--- a/ELECHOUSE_CC1101_SRC_DRV.cpp
+++ b/ELECHOUSE_CC1101_SRC_DRV.cpp
@@ -42,7 +42,7 @@ byte SS_PIN_M[max_modul];
 byte GDO0_M[max_modul];
 byte GDO2_M[max_modul];
 byte gdo_set=0;
-bool spi = 0;
+bool __spi = 0;
 bool ccmode = 0;
 float MHz = 433.92;
 byte m4RxBw = 0;
@@ -286,7 +286,7 @@ byte ELECHOUSE_CC1101::SpiReadStatus(byte addr)
 *OUTPUT       :none
 ****************************************************************/
 void ELECHOUSE_CC1101::setSpi(void){
-  if (spi == 0){
+  if (__spi == 0){
   #if defined __AVR_ATmega168__ || defined __AVR_ATmega328P__
   SCK_PIN = 13; MISO_PIN = 12; MOSI_PIN = 11; SS_PIN = 10;
   #elif defined __AVR_ATmega1280__ || defined __AVR_ATmega2560__
@@ -307,7 +307,7 @@ void ELECHOUSE_CC1101::setSpi(void){
 *OUTPUT       :none
 ****************************************************************/
 void ELECHOUSE_CC1101::setSpiPin(byte sck, byte miso, byte mosi, byte ss){
-  spi = 1;
+  __spi = 1;
   SCK_PIN = sck;
   MISO_PIN = miso;
   MOSI_PIN = mosi;
@@ -320,7 +320,7 @@ void ELECHOUSE_CC1101::setSpiPin(byte sck, byte miso, byte mosi, byte ss){
 *OUTPUT       :none
 ****************************************************************/
 void ELECHOUSE_CC1101::addSpiPin(byte sck, byte miso, byte mosi, byte ss, byte modul){
-  spi = 1;
+  __spi = 1;
   SCK_PIN_M[modul] = sck;
   MISO_PIN_M[modul] = miso;
   MOSI_PIN_M[modul] = mosi;

--- a/ELECHOUSE_CC1101_SRC_DRV.cpp
+++ b/ELECHOUSE_CC1101_SRC_DRV.cpp
@@ -24,6 +24,7 @@ cc1101 Driver for RC Switch. Mod by Little Satan. With permission to modify and 
 #define   BYTES_IN_RXFIFO   0x7F            //byte number in RXfifo
 #define   max_modul 6
 
+SPIClass ccSPI;
 byte modulation = 2;
 byte frend0;
 byte chan = 0;
@@ -93,9 +94,9 @@ void ELECHOUSE_CC1101::SpiStart(void)
 
   // enable SPI
   #ifdef ESP32
-  SPI.begin(SCK_PIN, MISO_PIN, MOSI_PIN, SS_PIN);
+  ccSPI.begin(SCK_PIN, MISO_PIN, MOSI_PIN, SS_PIN);
   #else
-  SPI.begin();
+  ccSPI.begin();
   #endif
 }
 /****************************************************************
@@ -107,8 +108,8 @@ void ELECHOUSE_CC1101::SpiStart(void)
 void ELECHOUSE_CC1101::SpiEnd(void)
 {
   // disable SPI
-  SPI.endTransaction();
-  SPI.end();
+  ccSPI.endTransaction();
+  ccSPI.end();
 }
 /****************************************************************
 *FUNCTION NAME: GDO_Set()
@@ -145,7 +146,7 @@ void ELECHOUSE_CC1101::Reset (void)
 	delay(1);
 	digitalWrite(SS_PIN, LOW);
 	while(digitalRead(MISO_PIN));
-  SPI.transfer(CC1101_SRES);
+  ccSPI.transfer(CC1101_SRES);
   while(digitalRead(MISO_PIN));
 	digitalWrite(SS_PIN, HIGH);
 }
@@ -177,8 +178,8 @@ void ELECHOUSE_CC1101::SpiWriteReg(byte addr, byte value)
   SpiStart();
   digitalWrite(SS_PIN, LOW);
   while(digitalRead(MISO_PIN));
-  SPI.transfer(addr);
-  SPI.transfer(value); 
+  ccSPI.transfer(addr);
+  ccSPI.transfer(value); 
   digitalWrite(SS_PIN, HIGH);
   SpiEnd();
 }
@@ -195,10 +196,10 @@ void ELECHOUSE_CC1101::SpiWriteBurstReg(byte addr, byte *buffer, byte num)
   temp = addr | WRITE_BURST;
   digitalWrite(SS_PIN, LOW);
   while(digitalRead(MISO_PIN));
-  SPI.transfer(temp);
+  ccSPI.transfer(temp);
   for (i = 0; i < num; i++)
   {
-  SPI.transfer(buffer[i]);
+  ccSPI.transfer(buffer[i]);
   }
   digitalWrite(SS_PIN, HIGH);
   SpiEnd();
@@ -214,7 +215,7 @@ void ELECHOUSE_CC1101::SpiStrobe(byte strobe)
   SpiStart();
   digitalWrite(SS_PIN, LOW);
   while(digitalRead(MISO_PIN));
-  SPI.transfer(strobe);
+  ccSPI.transfer(strobe);
   digitalWrite(SS_PIN, HIGH);
   SpiEnd();
 }
@@ -231,8 +232,8 @@ byte ELECHOUSE_CC1101::SpiReadReg(byte addr)
   temp = addr| READ_SINGLE;
   digitalWrite(SS_PIN, LOW);
   while(digitalRead(MISO_PIN));
-  SPI.transfer(temp);
-  value=SPI.transfer(0);
+  ccSPI.transfer(temp);
+  value=ccSPI.transfer(0);
   digitalWrite(SS_PIN, HIGH);
   SpiEnd();
   return value;
@@ -251,10 +252,10 @@ void ELECHOUSE_CC1101::SpiReadBurstReg(byte addr, byte *buffer, byte num)
   temp = addr | READ_BURST;
   digitalWrite(SS_PIN, LOW);
   while(digitalRead(MISO_PIN));
-  SPI.transfer(temp);
+  ccSPI.transfer(temp);
   for(i=0;i<num;i++)
   {
-  buffer[i]=SPI.transfer(0);
+  buffer[i]=ccSPI.transfer(0);
   }
   digitalWrite(SS_PIN, HIGH);
   SpiEnd();
@@ -273,8 +274,8 @@ byte ELECHOUSE_CC1101::SpiReadStatus(byte addr)
   temp = addr | READ_BURST;
   digitalWrite(SS_PIN, LOW);
   while(digitalRead(MISO_PIN));
-  SPI.transfer(temp);
-  value=SPI.transfer(0);
+  ccSPI.transfer(temp);
+  value=ccSPI.transfer(0);
   digitalWrite(SS_PIN, HIGH);
   SpiEnd();
   return value;

--- a/ELECHOUSE_CC1101_SRC_DRV.cpp
+++ b/ELECHOUSE_CC1101_SRC_DRV.cpp
@@ -13,7 +13,6 @@
 cc1101 Driver for RC Switch. Mod by Little Satan. With permission to modify and publish Wilson Shen (ELECHOUSE).
 ----------------------------------------------------------------------------------------------------------------
 */
-#include <SPI.h>
 #include "ELECHOUSE_CC1101_SRC_DRV.h"
 #include <Arduino.h>
 
@@ -24,7 +23,6 @@ cc1101 Driver for RC Switch. Mod by Little Satan. With permission to modify and 
 #define   BYTES_IN_RXFIFO   0x7F            //byte number in RXfifo
 #define   max_modul 6
 
-SPIClass ccSPI;
 byte modulation = 2;
 byte frend0;
 byte chan = 0;
@@ -79,6 +77,31 @@ uint8_t PA_TABLE_868[10] {0x03,0x17,0x1D,0x26,0x37,0x50,0x86,0xCD,0xC5,0xC0,};  
 //                        -30  -20  -15  -10  -6    0    5    7    10   11
 uint8_t PA_TABLE_915[10] {0x03,0x0E,0x1E,0x27,0x38,0x8E,0x84,0xCC,0xC3,0xC0,};  //900 - 928
 /****************************************************************
+*FUNCTION NAME:setSPIinstance
+*FUNCTION     :Set the SPI Instance to use if needed to share SPI Bus with other devices
+*INPUT        :none
+*OUTPUT       :none
+****************************************************************/
+void ELECHOUSE_CC1101::setSPIinstance(SPIClass* sspi) 
+{
+  // Set the SPI instance to use if needed to share SPI Bus with other devices
+  cc_spi=sspi;
+}
+/****************************************************************
+*FUNCTION NAME:getSPIinstance
+*FUNCTION     :Gives the SPI instance in use by CC1101, if none was set, will set the library SPI instance
+*INPUT        :none
+*OUTPUT       :none
+****************************************************************/
+SPIClass* ELECHOUSE_CC1101::getSPIinstance()
+{
+  if(cc_spi==nullptr) {
+    cc_spi=&_cc_spi;
+  }
+  return cc_spi;
+}
+
+/****************************************************************
 *FUNCTION NAME:SpiStart
 *FUNCTION     :spi communication start
 *INPUT        :none
@@ -86,18 +109,12 @@ uint8_t PA_TABLE_915[10] {0x03,0x0E,0x1E,0x27,0x38,0x8E,0x84,0xCC,0xC3,0xC0,};  
 ****************************************************************/
 void ELECHOUSE_CC1101::SpiStart(void)
 {
-  // initialize the SPI pins
-  pinMode(SCK_PIN, OUTPUT);
-  pinMode(MOSI_PIN, OUTPUT);
-  pinMode(MISO_PIN, INPUT);
-  pinMode(SS_PIN, OUTPUT);
+  //End transaction to ensure openin a new session with the right SPISettings
+  digitalWrite(SS_PIN, HIGH);
+  cc_spi->endTransaction();
+  digitalWrite(SS_PIN, LOW);
+  cc_spi->beginTransaction(SPISettings(2000000, MSBFIRST, SPI_MODE0));
 
-  // enable SPI
-  #ifdef ESP32
-  ccSPI.begin(SCK_PIN, MISO_PIN, MOSI_PIN, SS_PIN);
-  #else
-  ccSPI.begin();
-  #endif
 }
 /****************************************************************
 *FUNCTION NAME:SpiEnd
@@ -108,8 +125,9 @@ void ELECHOUSE_CC1101::SpiStart(void)
 void ELECHOUSE_CC1101::SpiEnd(void)
 {
   // disable SPI
-  ccSPI.endTransaction();
-  ccSPI.end();
+  digitalWrite(SS_PIN, HIGH);
+  cc_spi->endTransaction();
+
 }
 /****************************************************************
 *FUNCTION NAME: GDO_Set()
@@ -146,7 +164,7 @@ void ELECHOUSE_CC1101::Reset (void)
 	delay(1);
 	digitalWrite(SS_PIN, LOW);
 	while(digitalRead(MISO_PIN));
-  ccSPI.transfer(CC1101_SRES);
+  cc_spi->transfer(CC1101_SRES);
   while(digitalRead(MISO_PIN));
 	digitalWrite(SS_PIN, HIGH);
 }
@@ -158,14 +176,19 @@ void ELECHOUSE_CC1101::Reset (void)
 ****************************************************************/
 void ELECHOUSE_CC1101::Init(void)
 {
+  // check if SPI Pins are set
   setSpi();
-  SpiStart();                   //spi initialization
+  pinMode(SS_PIN, OUTPUT);
+  // If there were no different SPI Instance, use This lib instance
+  if(cc_spi==nullptr) {
+    cc_spi=&_cc_spi;
+    cc_spi->begin(SCK_PIN,MISO_PIN,MOSI_PIN);
+  }
+  SpiStart();                   //Start SPI Transaction
   digitalWrite(SS_PIN, HIGH);
-  digitalWrite(SCK_PIN, HIGH);
-  digitalWrite(MOSI_PIN, LOW);
-  Reset();                    //CC1101 reset
-  RegConfigSettings();            //CC1101 register config
-  SpiEnd();
+  Reset();                      //CC1101 reset
+  RegConfigSettings();          //CC1101 register config
+  SpiEnd();                     //Stops SPI Transaction
 }
 /****************************************************************
 *FUNCTION NAME:SpiWriteReg
@@ -176,12 +199,11 @@ void ELECHOUSE_CC1101::Init(void)
 void ELECHOUSE_CC1101::SpiWriteReg(byte addr, byte value)
 {
   SpiStart();
-  digitalWrite(SS_PIN, LOW);
   while(digitalRead(MISO_PIN));
-  ccSPI.transfer(addr);
-  ccSPI.transfer(value); 
-  digitalWrite(SS_PIN, HIGH);
+  cc_spi->transfer(addr);
+  cc_spi->transfer(value); 
   SpiEnd();
+  DEBUG_CC1101("Write reg addr: 0x" + String(addr,HEX) + "=0x" + String(value,HEX));
 }
 /****************************************************************
 *FUNCTION NAME:SpiWriteBurstReg
@@ -194,14 +216,15 @@ void ELECHOUSE_CC1101::SpiWriteBurstReg(byte addr, byte *buffer, byte num)
   byte i, temp;
   SpiStart();
   temp = addr | WRITE_BURST;
-  digitalWrite(SS_PIN, LOW);
   while(digitalRead(MISO_PIN));
-  ccSPI.transfer(temp);
+  DEBUG_CC11012("\nWrite burst addr: 0x" + String(temp,HEX) + "=");
+  cc_spi->transfer(temp);
   for (i = 0; i < num; i++)
   {
-  ccSPI.transfer(buffer[i]);
+  cc_spi->transfer(buffer[i]);
+  DEBUG_CC11012(" 0x" + String(buffer[i],HEX));
   }
-  digitalWrite(SS_PIN, HIGH);
+  DEBUG_CC1101
   SpiEnd();
 }
 /****************************************************************
@@ -213,11 +236,10 @@ void ELECHOUSE_CC1101::SpiWriteBurstReg(byte addr, byte *buffer, byte num)
 void ELECHOUSE_CC1101::SpiStrobe(byte strobe)
 {
   SpiStart();
-  digitalWrite(SS_PIN, LOW);
   while(digitalRead(MISO_PIN));
-  ccSPI.transfer(strobe);
-  digitalWrite(SS_PIN, HIGH);
+  cc_spi->transfer(strobe);
   SpiEnd();
+  DEBUG_CC1101("Write Strobe: 0x" + String(strobe,HEX));
 }
 /****************************************************************
 *FUNCTION NAME:SpiReadReg
@@ -230,12 +252,11 @@ byte ELECHOUSE_CC1101::SpiReadReg(byte addr)
   byte temp, value;
   SpiStart();
   temp = addr| READ_SINGLE;
-  digitalWrite(SS_PIN, LOW);
   while(digitalRead(MISO_PIN));
-  ccSPI.transfer(temp);
-  value=ccSPI.transfer(0);
-  digitalWrite(SS_PIN, HIGH);
+  cc_spi->transfer(temp);
+  value=cc_spi->transfer(0);
   SpiEnd();
+  DEBUG_CC1101("Reading addr: 0x" + String(addr,HEX) + " = 0x" + String(value,HEX));
   return value;
 }
 
@@ -250,14 +271,15 @@ void ELECHOUSE_CC1101::SpiReadBurstReg(byte addr, byte *buffer, byte num)
   byte i,temp;
   SpiStart();
   temp = addr | READ_BURST;
-  digitalWrite(SS_PIN, LOW);
   while(digitalRead(MISO_PIN));
-  ccSPI.transfer(temp);
+  DEBUG_CC11012("\nReading addr: 0x" + String(temp,HEX) + " = ");
+  cc_spi->transfer(temp);
   for(i=0;i<num;i++)
   {
-  buffer[i]=ccSPI.transfer(0);
+  buffer[i]=cc_spi->transfer(0);
+  DEBUG_CC11012(" " + String(buffer[i],HEX));
   }
-  digitalWrite(SS_PIN, HIGH);
+  DEBUG_CC1101
   SpiEnd();
 }
 
@@ -272,12 +294,11 @@ byte ELECHOUSE_CC1101::SpiReadStatus(byte addr)
   byte value,temp;
   SpiStart();
   temp = addr | READ_BURST;
-  digitalWrite(SS_PIN, LOW);
   while(digitalRead(MISO_PIN));
-  ccSPI.transfer(temp);
-  value=ccSPI.transfer(0);
-  digitalWrite(SS_PIN, HIGH);
+  cc_spi->transfer(temp);
+  value=cc_spi->transfer(0);
   SpiEnd();
+  DEBUG_CC1101("Reading Reg addr: 0x" + String(addr,HEX) + " = 0x" + String(value,HEX));
   return value;
 }
 /****************************************************************
@@ -616,11 +637,14 @@ clb4[1]=e;
 *OUTPUT       :none
 ****************************************************************/
 bool ELECHOUSE_CC1101::getCC1101(void){
-setSpi();
-if (SpiReadStatus(0x31)>0){
-return 1;
-}else{
-return 0;
+  setSpi();
+  byte val=SpiReadStatus(0x31);
+  if (val>0){
+    DEBUG_CC1101("getCC1101 result: 0x" + String(val,HEX) + " -> Ok");
+    return 1;
+  }else{
+    DEBUG_CC1101("getCC1101 result: 0x" + String(val,HEX) + " -> Not Found");
+    return 0;
 }
 }
 /****************************************************************

--- a/ELECHOUSE_CC1101_SRC_DRV.cpp
+++ b/ELECHOUSE_CC1101_SRC_DRV.cpp
@@ -70,7 +70,7 @@ byte clb4[2]= {77,79};
 /****************************************************************/
 uint8_t PA_TABLE[8]     {0x00,0xC0,0x00,0x00,0x00,0x00,0x00,0x00};
 //                       -30  -20  -15  -10   0    5    7    10
-uint8_t PA_TABLE_315[8] {0x12,0x0D,0x1C,0x34,0x51,0x85,0xCB,0xC2,};             //300 - 348
+uint8_t PA_TABLE_315[8] {0x12,0x0D,0x1C,0x34,0x51,0x85,0xCB,0xC2,};             //280 - 348
 uint8_t PA_TABLE_433[8] {0x12,0x0E,0x1D,0x34,0x60,0x84,0xC8,0xC0,};             //387 - 464
 //                        -30  -20  -15  -10  -6    0    5    7    10   12
 uint8_t PA_TABLE_868[10] {0x03,0x17,0x1D,0x26,0x37,0x50,0x86,0xCD,0xC5,0xC0,};  //779 - 899.99
@@ -498,7 +498,7 @@ void ELECHOUSE_CC1101::setPA(int p)
 int a;
 pa = p;
 
-if (MHz >= 300 && MHz <= 348){
+if (MHz >= 280 && MHz <= 348){
 if (pa <= -30){a = PA_TABLE_315[0];}
 else if (pa > -30 && pa <= -20){a = PA_TABLE_315[1];}
 else if (pa > -20 && pa <= -15){a = PA_TABLE_315[2];}
@@ -599,8 +599,8 @@ Calibrate();
 ****************************************************************/
 void ELECHOUSE_CC1101::Calibrate(void){
 
-if (MHz >= 300 && MHz <= 348){
-SpiWriteReg(CC1101_FSCTRL0, map(MHz, 300, 348, clb1[0], clb1[1]));
+if (MHz >= 280 && MHz <= 348){
+SpiWriteReg(CC1101_FSCTRL0, map(MHz, 280, 348, clb1[0], clb1[1]));
 if (MHz < 322.88){SpiWriteReg(CC1101_TEST0,0x0B);}
 else{
 SpiWriteReg(CC1101_TEST0,0x09);

--- a/ELECHOUSE_CC1101_SRC_DRV.cpp
+++ b/ELECHOUSE_CC1101_SRC_DRV.cpp
@@ -213,7 +213,7 @@ void ELECHOUSE_CC1101::Init(void)
     cc_spi=&_cc_spi;
     cc_spi->begin(SCK_PIN,MISO_PIN,MOSI_PIN,SS_PIN);
     delay(1);
-  } else DEBUG_CC1101("CC1101: Using other instance");
+  } else { DEBUG_CC1101("CC1101: Using other instance"); }
 
   SpiStart();                   //Start SPI Transaction
   digitalWrite(SS_PIN, HIGH);

--- a/ELECHOUSE_CC1101_SRC_DRV.cpp
+++ b/ELECHOUSE_CC1101_SRC_DRV.cpp
@@ -185,6 +185,9 @@ void ELECHOUSE_CC1101::GDO0_Set (void)
 ****************************************************************/
 bool ELECHOUSE_CC1101::checkMISO (void)
 {
+  // This function does not with IDF>=5, it delays the communication and makes the CC1101 not responding.
+  // So avoid using it in this situation
+  #if (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0))
   unsigned long timer = millis();
   while(digitalRead(MISO_PIN)){
     if(millis()-timer>1000) {
@@ -193,6 +196,7 @@ bool ELECHOUSE_CC1101::checkMISO (void)
       return false;
     }
   }
+  #endif
   return true;
 }
 /****************************************************************

--- a/ELECHOUSE_CC1101_SRC_DRV.h
+++ b/ELECHOUSE_CC1101_SRC_DRV.h
@@ -24,8 +24,8 @@ cc1101 Driver for RC Switch. Mod by Little Satan. With permission to modify and 
   #define DEBUG_CC1101(var) Serial.println(var);
   #define DEBUG_CC11012(var) Serial.print(var);
 #else
-  #define DEBUG_CC1101(var) 
-  #define DEBUG_CC11012(var)
+  #define DEBUG_CC1101(var) yield();
+  #define DEBUG_CC11012(var) yield();
 #endif
 
 //********************* DEBUG Macros  ********************/

--- a/ELECHOUSE_CC1101_SRC_DRV.h
+++ b/ELECHOUSE_CC1101_SRC_DRV.h
@@ -5,8 +5,8 @@
     Version: November 12, 2010
 
   This library is designed to use CC1101/CC1100 module on Arduino platform.
-  CC1101/CC1100 module is an useful wireless module.Using the functions of the 
-  library, you can easily send and receive data by the CC1101/CC1100 module. 
+  CC1101/CC1100 module is an useful wireless module.Using the functions of the
+  library, you can easily send and receive data by the CC1101/CC1100 module.
   Just have fun!
   For the details, please refer to the datasheet of CC1100/CC1101.
 ----------------------------------------------------------------------------------------------------------------
@@ -133,7 +133,8 @@ private:
   void SpiEnd(void);
   void GDO_Set (void);
   void GDO0_Set (void);
-  void Reset (void);
+  bool Reset (void);
+  bool checkMISO(void);
   void setSpi(void);
   void RegConfigSettings(void);
   void Calibrate(void);
@@ -146,7 +147,7 @@ private:
   SPIClass* cc_spi=nullptr;
   bool _begin_end_logic=false;
 public:
-  void Init(void);
+  bool Init(void);
   byte SpiReadStatus(byte addr);
   void setBeginEndLogic(bool state);
   bool getBeginEndLogic();
@@ -184,11 +185,11 @@ public:
   byte CheckReceiveFlag(void);
   byte ReceiveData(byte *rxBuffer);
   bool CheckCRC(void);
-  void SpiStrobe(byte strobe);
-  void SpiWriteReg(byte addr, byte value);
-  void SpiWriteBurstReg(byte addr, byte *buffer, byte num);
+  bool SpiStrobe(byte strobe);
+  bool SpiWriteReg(byte addr, byte value);
+  bool SpiWriteBurstReg(byte addr, byte *buffer, byte num);
   byte SpiReadReg(byte addr);
-  void SpiReadBurstReg(byte addr, byte *buffer, byte num);
+  bool SpiReadBurstReg(byte addr, byte *buffer, byte num);
   void setClb(byte b, byte s, byte e);
   bool getCC1101(void);
   byte getMode(void);

--- a/ELECHOUSE_CC1101_SRC_DRV.h
+++ b/ELECHOUSE_CC1101_SRC_DRV.h
@@ -16,7 +16,22 @@ cc1101 Driver for RC Switch. Mod by Little Satan. With permission to modify and 
 #ifndef ELECHOUSE_CC1101_SRC_DRV_h
 #define ELECHOUSE_CC1101_SRC_DRV_h
 
+//********************* DEBUG Macros  ********************/
+
+// Uncomment line below to have Serial messagens about the transactions
+//#define CC1101_LIB_DEBUG
+#if defined(CC1101_LIB_DEBUG)
+  #define DEBUG_CC1101(var) Serial.println(var);
+  #define DEBUG_CC11012(var) Serial.print(var);
+#else
+  #define DEBUG_CC1101(var) 
+  #define DEBUG_CC11012(var)
+#endif
+
+//********************* DEBUG Macros  ********************/
+
 #include <Arduino.h>
+#include <SPI.h>
 
 //***************************************CC1101 define**************************************************//
 // CC1101 CONFIG REGSITER
@@ -127,9 +142,13 @@ private:
   void Split_MDMCFG1(void);
   void Split_MDMCFG2(void);
   void Split_MDMCFG4(void);
+  SPIClass _cc_spi;
+  SPIClass* cc_spi=nullptr;
 public:
   void Init(void);
   byte SpiReadStatus(byte addr);
+  void setSPIinstance(SPIClass* sspi);
+  SPIClass* getSPIinstance();
   void setSpiPin(byte sck, byte miso, byte mosi, byte ss);
   void addSpiPin(byte sck, byte miso, byte mosi, byte ss, byte modul);
   void setGDO(byte gdo0, byte gdo2);

--- a/ELECHOUSE_CC1101_SRC_DRV.h
+++ b/ELECHOUSE_CC1101_SRC_DRV.h
@@ -144,9 +144,12 @@ private:
   void Split_MDMCFG4(void);
   SPIClass _cc_spi;
   SPIClass* cc_spi=nullptr;
+  bool _begin_end_logic=false;
 public:
   void Init(void);
   byte SpiReadStatus(byte addr);
+  void setBeginEndLogic(bool state);
+  bool getBeginEndLogic();
   void setSPIinstance(SPIClass* sspi);
   SPIClass* getSPIinstance();
   void setSpiPin(byte sck, byte miso, byte mosi, byte ss);

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ The most important functions at a glance:
 
 ELECHOUSE_cc1101.Init();		//Initialize the cc1101. Must be set first!
 
+ELECHOUSE_cc1101.setSPIinstance(&spi_instance);	// Used to share SPI bus with other devices (tft, SDCard or other devices)
+												// to share SPI cus with a display (TFT_eSPI), use ELECHOUSE_cc1101.setSPIinstance(&tft.getSPIinstance());
+												// if sharing with TFT_eSPI device, is neede to call some SPI Function to "release" the CC1101, like tft.
+												// like: tft.drawPixel(0,0,0); after finishing setting the CC1101.
+												// if none is set, it will use this lib instance, instead
+
+ELECHOUSE_cc1101.getSPIinstance(); // Gets the SPI Instance to use with other object, like SDCard or other thing
+
 ELECHOUSE_cc1101.setPA(PA);		//Set transmission power.
 
 ELECHOUSE_cc1101.setMHZ(MHZ);		//Set the basic frequency.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ The most important functions at a glance:
 
 ELECHOUSE_cc1101.Init();		//Initialize the cc1101. Must be set first!
 
+ELECHOUSE_cc1101.setBeginEndLogic(value)		// Set the same logic of begin and end the SPI instance, like the original state
+
+ELECHOUSE_cc1101.getBeginEndLogic()				// Gives the actual mode of operation
+
 ELECHOUSE_cc1101.setSPIinstance(&spi_instance);	// Used to share SPI bus with other devices (tft, SDCard or other devices)
 												// to share SPI cus with a display (TFT_eSPI), use ELECHOUSE_cc1101.setSPIinstance(&tft.getSPIinstance());
 												// if sharing with TFT_eSPI device, is neede to call some SPI Function to "release" the CC1101, like tft.


### PR DESCRIPTION
The original state of this library **doens't allow** us to share the SPI bus with other devices, such as TFT and SD Card.

I am working on [Bruce Firmware](https://github.com/pr3y/Bruce), and wanted to use this library to control a CC1101 and faced this issue, so I found a way to solve this problem and make the lib work on devices such as [M5Cardputer ](https://github.com/pr3y/Bruce/wiki/CC1101) (sharing SPI bus with SD Card using a SdCard Sniffer) and finally with[ Lyligo T-Embed CC1101](https://www.lilygo.cc/products/t-embed-cc1101) (CC1101 is mounted sharing the bus with Display and SD Card)

The changes I've made are:
- Created a SPIClass instance for the library, for better control of the bus,
- Added a function called **setSPIinstance(SPIClass* sspi)**, where you can specify which SPI class to use when sharing the SPI bus (This instance must have been initialized before using init() function)
- Added a function called **getSPIinstance()**, if ou want to specify the other device to use the CC1101 instance after starting CC1101 (in this case is good to turn off a logic called BeginEndLogic.
- If no Instance was specified, the Init function will point to the SPIClass of the library, and using the SPI.begin(..) and SPI.end() Logic that is used atm.
- this logic can be activated and deactivated using **setBeginEndLogic(bool)**, and the state of this logic using **getBeginEndLogic()**;


Thank you for this lib, I hope my contribuitions can make the difference in your projects.
