### PR TITLE
Allow set spi clock speed

### DIFF
--- a/SmartRC_CC1101.cpp
+++ b/SmartRC_CC1101.cpp
@@ -12,8 +12,6 @@
 // CENTRAL QUARTZ DEFINITION (Can be changed by the user for 27MHz crystals)
 #define F_OSC           26000000.0f 
 
-#define CC1101_SPI_SETTINGS SPISettings(4000000, MSBFIRST, SPI_MODE0)
-
 const uint8_t PA_TABLE_315[8]  = {0x12,0x0D,0x1C,0x34,0x51,0x85,0xCB,0xC2};
 const uint8_t PA_TABLE_433[8]  = {0x12,0x0E,0x1D,0x34,0x60,0x84,0xC8,0xC0};
 const uint8_t PA_TABLE_868[10] = {0x03,0x17,0x1D,0x26,0x37,0x50,0x86,0xCD,0xC5,0xC0};
@@ -46,7 +44,7 @@ bool SmartRC_CC1101::WaitMiso(uint16_t timeout_ms) {
 }
 
 void SmartRC_CC1101::SpiStart(void) {
-    SPI.beginTransaction(CC1101_SPI_SETTINGS);
+    SPI.beginTransaction(spi_settings);
     digitalWrite(SS_PIN, LOW);
 }
 
@@ -184,6 +182,10 @@ void SmartRC_CC1101::Init(void) {
     
     Reset();
     RegConfigSettings();
+}
+
+void SmartRC_CC1101::setClock(uint32_t clock) {
+    spi_settings = spi_settings = SPISettings(clock, MSBFIRST, SPI_MODE0);
 }
 
 void SmartRC_CC1101::setSpiPinMode(void) {

--- a/SmartRC_CC1101.h
+++ b/SmartRC_CC1101.h
@@ -114,6 +114,7 @@ private:
   bool custom_spi_pins = false;
   bool ccmode = false;
   float MHz = 433.92;
+  SPISettings spi_settings = SPISettings(4000000, MSBFIRST, SPI_MODE0);
   byte trxstate = 0;
   byte clb1[2] = {24, 28};
   byte clb2[2] = {31, 38};
@@ -132,6 +133,7 @@ private:
   void setSpiPinMode(void);
 public:
   void Init(void);
+  void setClock(uint32_t clock);
   byte SpiReadStatus(byte addr);
   void setSpiPin(byte sck, byte miso, byte mosi, byte ss);
   void setGDO(byte gdo0, byte gdo2);


### PR DESCRIPTION
I use [wmbus with esphome](https://github.com/SzczepanLeon/esphome-components/tree/version_3). The distance between cc1101 and esp board is long (~5m), i have to reduce the speed to work.